### PR TITLE
v3.2.0: Add support for grouped menu items and href alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The rendered mode normally follows the viewport, but it can also be controlled w
 npm install react-icon-sidebar react react-icons
 ```
 
-1. Import the component styles, your icon components, and `SideMenu`:
+2. Import the component styles, your icon components, and `SideMenu`:
 
 ```javascript
 import "react-icon-sidebar/dist/react-icon-sidebar.css";
@@ -40,9 +40,11 @@ import SideMenu from "react-icon-sidebar";
 import { MdAddCircle, MdStar, MdPerson } from "react-icons/md";
 ```
 
-1. Build a `menu` array.
+3. Build a `menu` array.
 
-Note: an object with `hr: true` renders a horizontal separator.
+**Note**: an object with `hr: true` renders a horizontal separator.
+**Note**: `href` can be used anywhere `link` is expected.
+**Note**: Group items and group links *do not* appear in compact mode (768px - 1360px).
 
 ```javascript
 const menu = [
@@ -64,10 +66,23 @@ const menu = [
         text: "Agent",
         link: "/agent",
     },
+    {
+        groupTitle: "Show more",
+        groupItems: [
+            {
+                text: "Group link 1",
+                link: "/group-link-1",
+            },
+            {
+                text: "Group link 2",
+                href: "/group-link-2",
+            }
+        ]
+    },
 ];
 ```
 
-1. Pass the `menu` array to the component:
+4. Pass the `menu` array to the component:
 
 ```jsx
 <SideMenu menu={menu} />
@@ -99,13 +114,36 @@ Each object in the `menu` array must be one of the following:
 
 | Property | Type | Description |
 | --- | --- | --- |
-| icon | React component | Icon component (for example from [react-icons](https://react-icons.github.io/react-icons/)). |
+| icon | React component | Icon component (for example from [react-icons](https://react-icons.github.io/react-icons/)). Optional |
 | text | string | Visible menu label. Must be non-empty. |
 | link | string | Destination URL/path. Must be non-empty. |
+| href | string | Alias for `link`. Either `link` or `href` must be provided. |
 
 OR
 
-1. Separator item
+2. Group item (expand/collapse)
+**NOTE**: Group items and group links *do not* appear in compact mode
+
+| Property | Type | Description |
+| --- | --- | --- |
+| icon | React component | Icon component shown next to the group title. Optional |
+| groupTitle | string | Visible group label. Must be non-empty. |
+| groupItems | array | Non-empty list of group links (see below). |
+| expanded | boolean | Optional initial expanded state for the group. |
+
+Group item link shape:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| text | string | Visible child label. Must be non-empty. |
+| link | string | Destination URL/path. |
+| href | string | Alias for `link`. Either `link` or `href` must be provided. |
+
+*NOTE*
+
+OR
+
+3. Separator item
 
 | Property | Type | Description |
 | --- | --- | --- |
@@ -119,8 +157,9 @@ Validation rules for `menu`:
 
 1. `menu` must be an array.
 2. Every entry must be an object.
-3. If `hr !== true`, the entry must include `icon`, `text`, and `link`.
-4. `text` and `link` must be non-empty strings.
+3. If `groupTitle` is present, it must be a non-empty string and `groupItems` must be a non-empty array.
+4. Each `groupItems` entry must include non-empty `text` and either non-empty `link` or non-empty `href`.
+5. If `hr !== true` and `groupTitle` is not present, the entry must include `icon`, non-empty `text`, and either non-empty `link` or non-empty `href`.
 
 ## Behavior
 
@@ -129,6 +168,8 @@ Validation rules for `menu`:
 3. Compact and full: the menu stays visible by default.
 4. `showToggle`: when enabled, the hamburger button stays visible at every size and can hide or show the menu.
 5. Active item: when `window.location.pathname` matches a menu item's `link`, that item receives active styling and `aria-current="page"`.
+6. Groups: when `groupItems` are present, the group title toggles expand/collapse and child links render underneath it when expanded.
+7. Groups **do not** render when the menu is in compact mode.
 
 ## Accessibility
 

--- a/__tests__/SideMenu.test.js
+++ b/__tests__/SideMenu.test.js
@@ -18,6 +18,41 @@ const defaultMenu = [
     },
 ];
 
+const groupedMenu = [
+    {
+        icon: MdStar,
+        groupTitle: "Group",
+        groupItems: [
+            {
+                text: "Child One",
+                link: "/child-one",
+            },
+            {
+                text: "Child Two",
+                link: "/child-two",
+            },
+        ],
+    },
+];
+
+const hrefAliasMenu = [
+    {
+        icon: MdStar,
+        text: "Href Top",
+        href: "/href-top",
+    },
+    {
+        icon: MdStar,
+        groupTitle: "Href Group",
+        groupItems: [
+            {
+                text: "Href Child",
+                href: "/href-child",
+            },
+        ],
+    },
+];
+
 const setViewportWidth = width => {
     Object.defineProperty(window, "innerWidth", {
         configurable: true,
@@ -171,4 +206,55 @@ test("resize updates are debounced", () => {
     } finally {
         jest.useRealTimers();
     }
+});
+
+test("grouped items expand and collapse beneath the group title", () => {
+    render(<SideMenu menu={groupedMenu} force="full" />);
+
+    const groupToggle = screen.getByRole("button", { name: "Group" });
+
+    expect(groupToggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("link", { name: "Child One" })).toBeNull();
+
+    fireEvent.click(groupToggle);
+
+    expect(groupToggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("link", { name: "Child One" })).toBeInTheDocument();
+
+    fireEvent.click(groupToggle);
+
+    expect(groupToggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("link", { name: "Child One" })).toBeNull();
+});
+
+test("grouped menu auto-expands when a group child route is active", () => {
+    window.history.pushState({}, "", "/child-two");
+    render(<SideMenu menu={groupedMenu} force="full" />);
+
+    const groupToggle = screen.getByRole("button", { name: "Group" });
+    const activeGroupLink = screen.getByRole("link", { name: "Child Two" });
+
+    expect(groupToggle).toHaveAttribute("aria-expanded", "true");
+    expect(activeGroupLink).toHaveAttribute("aria-current", "page");
+});
+
+test("href works as an alias for link on top-level and grouped items", () => {
+    window.history.pushState({}, "", "/href-top");
+    const { rerender } = render(<SideMenu menu={hrefAliasMenu} force="full" />);
+
+    const topLevelHrefLink = screen.getByRole("link", { name: "Href Top" });
+    expect(topLevelHrefLink).toHaveAttribute("href", "/href-top");
+    expect(topLevelHrefLink).toHaveAttribute("aria-current", "page");
+
+    window.history.pushState({}, "", "/href-child");
+    rerender(<SideMenu menu={hrefAliasMenu} force="full" />);
+
+    const groupToggle = screen.getByRole("button", { name: "Href Group" });
+    fireEvent.click(groupToggle);
+
+    const groupHrefLink = screen.getByRole("link", { name: "Href Child" });
+
+    expect(groupToggle).toHaveAttribute("aria-expanded", "true");
+    expect(groupHrefLink).toHaveAttribute("href", "/href-child");
+    expect(groupHrefLink).toHaveAttribute("aria-current", "page");
 });

--- a/demo/src/App.jsx
+++ b/demo/src/App.jsx
@@ -17,7 +17,7 @@ const menu = [
     {
         icon: MdAddCircle,
         text: "New",
-        link: "/new",
+        href: "/new",
     },
     {
         icon: MdFavorite,
@@ -36,6 +36,20 @@ const menu = [
         icon: MdSupportAgent,
         text: "Support",
         link: "/support",
+    },
+    {
+        groupTitle: "Show more",
+        expanded: false,
+        groupItems: [
+            {
+                text: "Group Item 1",
+                link: "/group-item-1",
+            },
+            {
+                text: "Group Item 2",
+                link: "/group-item-2",
+            },
+        ],
     },
 ];
 
@@ -61,7 +75,7 @@ const App = () => {
 
     return (
         <div className="demo-app">
-            <SideMenu key={pathname} menu={menu} />
+            <SideMenu key={pathname} menu={menu} showToggle />
             <main className="demo-content">
                 <h1>react-icon-sidebar visual test</h1>
                 <p>
@@ -71,15 +85,29 @@ const App = () => {
                 <div className="demo-actions">
                     {menu
                         .filter(item => item.hr !== true)
-                        .map(item => (
-                            <button
-                                key={item.link}
-                                type="button"
-                                onClick={() => navigate(item.link)}
-                            >
-                                {item.text}
-                            </button>
-                        ))}
+                        .map(item =>
+                            typeof item.groupTitle !== "undefined" ? (
+                                item.groupItems.map(groupItem => (
+                                    <button
+                                        key={groupItem.link}
+                                        type="button"
+                                        onClick={() => navigate(groupItem.link)}
+                                    >
+                                        {groupItem.text}
+                                    </button>
+                                ))
+                            ) : (
+                                <button
+                                    key={item.link || item.href}
+                                    type="button"
+                                    onClick={() =>
+                                        navigate(item.link || item.href)
+                                    }
+                                >
+                                    {item.text}
+                                </button>
+                            ),
+                        )}
                 </div>
                 <p>
                     Current route: <code>{pathname}</code>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-icon-sidebar",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-icon-sidebar",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "react-icons": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-icon-sidebar",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "description": "A responsive iconographic side-menu component for React apps",
   "main": "dist/react-icon-sidebar.es.js",
   "module": "dist/react-icon-sidebar.es.js",

--- a/src/SideMenu.jsx
+++ b/src/SideMenu.jsx
@@ -101,15 +101,50 @@ const validateMenu = menu => {
             continue;
         }
 
-        if (!item.icon || typeof item.icon !== "function") {
-            return `SideMenu: menu[${i}] requires an icon component when hr is not true.`;
+        if (item.groupTitle) {
+            if (
+                typeof item.groupTitle !== "string" ||
+                item.groupTitle.trim() === ""
+            ) {
+                return `SideMenu: menu[${i}] has an invalid groupTitle. If present, groupTitle must be a non-empty string.`;
+            }
+            if (
+                !Array.isArray(item.groupItems) ||
+                item.groupItems.length === 0
+            ) {
+                return `SideMenu: menu[${i}] has an invalid groupItems. If groupTitle is present, groupItems must be a non-empty array.`;
+            }
+            for (let j = 0; j < item.groupItems.length; j += 1) {
+                const groupItem = item.groupItems[j];
+                if (!groupItem || typeof groupItem !== "object") {
+                    return `SideMenu: menu[${i}].groupItems[${j}] must be an object.`;
+                }
+                if (
+                    typeof groupItem.text !== "string" ||
+                    groupItem.text.trim() === ""
+                ) {
+                    return `SideMenu: menu[${i}].groupItems[${j}] requires a non-empty text string.`;
+                }
+                if (
+                    (typeof groupItem.link !== "string" ||
+                        groupItem.link.trim() === "") &&
+                    (typeof groupItem.href !== "string" ||
+                        groupItem.href.trim() === "")
+                ) {
+                    return `SideMenu: menu[${i}].groupItems[${j}] requires a non-empty link string.`;
+                }
+            }
+            continue;
         }
 
         if (typeof item.text !== "string" || item.text.trim() === "") {
             return `SideMenu: menu[${i}] requires a non-empty text string when hr is not true.`;
         }
 
-        if (typeof item.link !== "string" || item.link.trim() === "") {
+        if (
+            (typeof item.link !== "string" || item.link.trim() === "") &&
+            (typeof item.href !== "string" || item.href.trim() === "")
+        ) {
             return `SideMenu: menu[${i}] requires a non-empty link string when hr is not true.`;
         }
     }
@@ -229,17 +264,23 @@ const SideMenu = ({
                 {shouldShowToggle ? <div style={{ height: "2.5em" }} /> : null}
                 {menu.map((item, index) => {
                     if (item.hr !== true) {
+                        if (item.groupTitle && renderedMode === "compact")
+                            return null;
                         return (
                             <MenuItem
                                 key={
                                     item.link ||
+                                    item.href ||
+                                    item.groupTitle ||
                                     item.text ||
                                     `menu-item-${index}`
                                 }
                                 id={index}
                                 icon={item.icon}
-                                text={item.text}
-                                link={item.link}
+                                text={item.text || item.groupTitle}
+                                link={item.link || item.href}
+                                groupItems={item.groupItems}
+                                expanded={item.expanded}
                                 mode={renderedMode}
                             />
                         );

--- a/src/components/MenuItem.css
+++ b/src/components/MenuItem.css
@@ -1,6 +1,10 @@
 .menu-item {
     color: inherit;
     text-decoration: none;
+    border: 0;
+    background: transparent;
+    font: inherit;
+    text-align: left;
 }
 
 .menu-item:hover {
@@ -10,6 +14,20 @@
 .menu-item:active,
 .active {
     color: #66f !important;
+}
+
+.menu-item-group-link {
+    color: inherit;
+    text-decoration: none;
+    border-radius: 0.25rem;
+}
+
+.menu-item-group-link:hover {
+    background-color: rgba(0, 0, 0, 0.08);
+}
+
+.menu-item-group-link-active {
+    color: #66f;
 }
 
 hr {

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -1,4 +1,5 @@
-import React, { memo, useMemo } from "react";
+import React, { memo, useEffect, useMemo, useState } from "react";
+import { MdExpandLess, MdExpandMore } from "react-icons/md";
 import "./MenuItem.css";
 
 const sharedMenuItem = {
@@ -31,6 +32,17 @@ const sharedMenuItemText = {
     verticalAlign: "middle",
 };
 
+const sharedGroupList = {
+    display: "flex",
+    flexDirection: "column",
+    marginTop: "1em",
+};
+
+const sharedGroupListItem = {
+    color: "inherit",
+    textDecoration: "none",
+};
+
 const styles = {
     mobile: {
         menuItem: {
@@ -52,6 +64,16 @@ const styles = {
             whiteSpace: "nowrap",
             margin: "0 1em 0 1em",
         },
+        groupList: {
+            ...sharedGroupList,
+            width: "100%",
+        },
+        groupListItem: {
+            ...sharedGroupListItem,
+            display: "block",
+            padding: "0.35em 1em",
+            fontSize: "0.95em",
+        },
     },
     compact: {
         menuItem: {
@@ -68,6 +90,18 @@ const styles = {
             ...sharedMenuItemText,
             fontSize: "0.75em",
             whiteSpace: "nowrap",
+        },
+        groupList: {
+            ...sharedGroupList,
+            width: "100%",
+            alignItems: "center",
+        },
+        groupListItem: {
+            ...sharedGroupListItem,
+            display: "block",
+            padding: "0.2em 0",
+            fontSize: "0.72em",
+            textAlign: "center",
         },
     },
     full: {
@@ -90,6 +124,16 @@ const styles = {
             whiteSpace: "nowrap",
             margin: "0 1em 0 1em",
         },
+        groupList: {
+            ...sharedGroupList,
+            width: "100%",
+        },
+        groupListItem: {
+            ...sharedGroupListItem,
+            display: "block",
+            padding: "0.35em 1em",
+            fontSize: "0.95em",
+        },
     },
 };
 
@@ -103,20 +147,53 @@ const getCurrentPath = () => {
 
 const getStylesForMode = mode => styles[mode] || styles.compact;
 
-const MenuItem = ({ id, icon: Icon, text, link, mode = "compact" }) => {
-    const menuStyles = getStylesForMode(mode);
-    const className = useMemo(
-        () => (getCurrentPath() === link ? "menu-item active" : "menu-item"),
-        [link],
+const hasMatchingLink = (items, currentPath) =>
+    items.some(
+        item =>
+            item && (item.link === currentPath || item.href === currentPath),
     );
 
-    return (
+const getItemHref = item => item.link || item.href || "#";
+
+const MenuItem = ({
+    id,
+    icon: Icon,
+    text,
+    link,
+    groupItems = [],
+    expanded = false,
+    mode = "compact",
+}) => {
+    const menuStyles = getStylesForMode(mode);
+    const hasGroupItems = groupItems.length > 0;
+    const currentPath = getCurrentPath();
+    const hasActiveGroupItem =
+        hasGroupItems && hasMatchingLink(groupItems, currentPath);
+    const [isGroupExpanded, setIsGroupExpanded] = useState(
+        expanded || hasActiveGroupItem,
+    );
+    const className = useMemo(
+        () =>
+            getCurrentPath() === link || hasActiveGroupItem
+                ? "menu-item active"
+                : "menu-item",
+        [hasActiveGroupItem, link],
+    );
+
+    useEffect(() => {
+        if (hasActiveGroupItem) {
+            setIsGroupExpanded(true);
+        }
+    }, [hasActiveGroupItem]);
+
+    const renderItemAnchor = (index, link, className, style, Icon, text) => (
         <a
+            key={`${link}-${index}`}
             id={"menu-item-" + id}
             className={className}
             href={link || "#"}
             aria-current={className.includes("active") ? "page" : undefined}
-            style={menuStyles.menuItem}
+            style={style}
         >
             <div className="menu-item-icon" style={menuStyles.menuItemIcon}>
                 {Icon ? <Icon size="2em" /> : null}
@@ -125,6 +202,74 @@ const MenuItem = ({ id, icon: Icon, text, link, mode = "compact" }) => {
                 {text}
             </div>
         </a>
+    );
+
+    if (hasGroupItems) {
+        const groupId = `menu-item-group-${id}`;
+
+        return (
+            <>
+                <button
+                    id={"menu-item-" + id}
+                    type="button"
+                    className={className}
+                    aria-controls={groupId}
+                    aria-expanded={isGroupExpanded}
+                    style={menuStyles.menuItem}
+                    onClick={() => setIsGroupExpanded(prev => !prev)}
+                >
+                    <div
+                        className="menu-item-icon"
+                        style={menuStyles.menuItemIcon}
+                    >
+                        {Icon ? <Icon size="2em" /> : null}
+                    </div>
+                    <div
+                        className="menu-item-text"
+                        style={menuStyles.menuItemText}
+                    >
+                        {text}
+                    </div>
+                    {isGroupExpanded ? (
+                        <MdExpandLess size="1.5em" />
+                    ) : (
+                        <MdExpandMore size="1.5em" />
+                    )}
+                </button>
+                {isGroupExpanded ? (
+                    <div
+                        id={groupId}
+                        className="menu-item-group"
+                        style={menuStyles.groupList}
+                    >
+                        {groupItems.map((groupItem, index) => {
+                            const groupItemHref = getItemHref(groupItem);
+                            const isActive = groupItemHref === currentPath;
+
+                            return renderItemAnchor(
+                                index,
+                                groupItemHref,
+                                isActive
+                                    ? "menu-item-group-link menu-item-group-link-active"
+                                    : "menu-item-group-link",
+                                menuStyles.groupListItem,
+                                null,
+                                groupItem.text,
+                            );
+                        })}
+                    </div>
+                ) : null}
+            </>
+        );
+    }
+
+    return renderItemAnchor(
+        id,
+        link,
+        className,
+        menuStyles.menuItem,
+        Icon,
+        text,
     );
 };
 


### PR DESCRIPTION
- Implemented grouping functionality for menu items, allowing for expandable/collapsible groups in full and mobile modes (autohidden in compact mode).
- Added validation for group items in the menu structure.
- Updated MenuItem component to handle group items and their expansion state.
- Enhanced styling for group links in MenuItem.css.
- Modified demo App to showcase new group item feature and href aliasing for links.