### PR TITLE
Add title item support to menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ import { MdAddCircle, MdStar, MdPerson } from "react-icons/md";
 3. Build a `menu` array.
 
 **Note**: an object with `hr: true` renders a horizontal separator.
+**Note**: an object with `isTitleItem: true` renders the contents of `text` as a non-clickable title
 **Note**: `href` can be used anywhere `link` is expected.
 
 ```javascript
@@ -61,6 +62,10 @@ const menu = [
     },
     {
         hr: true,
+    },
+    {
+        isTitleItem: true,
+        text: "Additional Links",
     },
     {
         icon: MdPerson,
@@ -147,6 +152,12 @@ OR
 | --- | --- | --- |
 | hr | boolean | If `true`, renders a horizontal separator line. |
 
+4. Title item
+
+| Property | Type | Description|
+| isTitleItem | boolean | If `true` renders the value of the `text` property as a title. |
+| text | string | Visible title text. Must be non-empty. |
+
 ## Runtime Validation
 
 `SideMenu` includes development-time runtime validation for `menu`.
@@ -167,6 +178,7 @@ Validation rules for `menu`:
 4. `showToggle`: when enabled, the hamburger button stays visible at every size and can hide or show the menu.
 5. Active item: when `window.location.pathname` matches a menu item's `link`, that item receives active styling and `aria-current="page"`.
 6. Groups: when `groupItems` are present, the group title toggles expand/collapse and child links render underneath it when expanded.
+7. Titles: when `isTitleItem` is set to `true`, the string `text` renders as a non-clickable title.
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ OR
 | --- | --- | --- |
 | hr | boolean | If `true`, renders a horizontal separator line. |
 
+OR
+
 4. Title item
 
 | Property | Type | Description|

--- a/demo/src/App.jsx
+++ b/demo/src/App.jsx
@@ -28,6 +28,10 @@ const menu = [
         hr: true,
     },
     {
+        isTitleItem: true,
+        text: "Additional Links",
+    },
+    {
         icon: MdSettings,
         text: "Settings",
         link: "/settings",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-icon-sidebar",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-icon-sidebar",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "react-icons": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-icon-sidebar",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A responsive iconographic side-menu component for React apps",
   "main": "dist/react-icon-sidebar.es.js",
   "module": "dist/react-icon-sidebar.es.js",

--- a/src/SideMenu.css
+++ b/src/SideMenu.css
@@ -40,6 +40,10 @@
     transition: ease-in 300ms;
 }
 
+.pointer {
+    cursor: pointer;
+}
+
 #menu-whitespace-target {
     transition: linear 300ms;
 }

--- a/src/SideMenu.jsx
+++ b/src/SideMenu.jsx
@@ -242,6 +242,7 @@ const SideMenu = ({
                                 link={item.link || item.href}
                                 groupItems={item.groupItems}
                                 expanded={item.expanded}
+                                isTitleItem={item.isTitleItem}
                                 mode={renderedMode}
                             />
                         );

--- a/src/components/MenuItem.css
+++ b/src/components/MenuItem.css
@@ -33,3 +33,11 @@
 hr {
     margin-top: 2rem !important;
 }
+
+.menu-item-title {
+    font-weight: bold;
+
+    &:hover {
+        background-color: inherit;
+    }
+}

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -29,6 +29,7 @@ const MenuItem = ({
     link,
     groupItems = [],
     expanded = false,
+    isTitleItem = false,
     mode = "compact",
 }) => {
     const menuStyles = getStylesForMode(mode);
@@ -46,12 +47,6 @@ const MenuItem = ({
                 : "menu-item",
         [hasActiveGroupItem, link],
     );
-
-    useEffect(() => {
-        if (hasActiveGroupItem) {
-            setIsGroupExpanded(true);
-        }
-    }, [hasActiveGroupItem]);
 
     const renderItemAnchor = (index, link, className, style, Icon, text) => (
         <a
@@ -73,6 +68,26 @@ const MenuItem = ({
         </a>
     );
 
+    useEffect(() => {
+        if (hasActiveGroupItem) {
+            setIsGroupExpanded(true);
+        }
+    }, [hasActiveGroupItem]);
+
+    if (isTitleItem) {
+        return (
+            <div
+                id={"menu-item-" + id}
+                className="menu-item menu-item-title"
+                style={menuStyles.menuItem}
+            >
+                <div cssName="menu-item-text" style={menuStyles.menuItemText}>
+                    {text}
+                </div>
+            </div>
+        );
+    }
+
     if (hasGroupItems) {
         const groupId = `menu-item-group-${id}`;
 
@@ -82,9 +97,9 @@ const MenuItem = ({
                     id={"menu-item-" + id}
                     type="button"
                     className={
-                        mode === "compact"
+                        (mode === "compact"
                             ? className
-                            : "menu-item menu-item-group"
+                            : "menu-item menu-item-group") + " pointer"
                     }
                     aria-haspopup="true"
                     aria-controls={groupId}

--- a/src/components/MenuItem.styles.js
+++ b/src/components/MenuItem.styles.js
@@ -3,7 +3,6 @@ const sharedMenuItem = {
     outline: 0,
     display: "flex",
     alignItems: "center",
-    cursor: "pointer",
     color: "inherit",
     textDecoration: "none",
     position: "relative",
@@ -20,11 +19,8 @@ const sharedMenuItemIcon = {
 
 const sharedMenuItemText = {
     maxWidth: "100%",
-    maxHeight: "1.4rem",
     overflow: "hidden",
     textOverflow: "ellipsis",
-    fontWeight: 400,
-    lineHeight: "1.4rem",
     verticalAlign: "middle",
 };
 
@@ -77,6 +73,7 @@ export const styles = {
             width: "4.5rem",
             flexDirection: "column",
             justifyContent: "center",
+            textAlign: "center",
         },
         menuItemIcon: {
             ...sharedMenuItemIcon,
@@ -85,7 +82,7 @@ export const styles = {
         menuItemText: {
             ...sharedMenuItemText,
             fontSize: "0.75rem",
-            whiteSpace: "nowrap",
+            textOverflow: "wrap",
         },
         groupList: {
             ...sharedGroupList,


### PR DESCRIPTION
- Introduced `isTitleItem` property to render non-clickable titles in the menu
- Updated README with new title item usage instructions
- Modified `MenuItem` component to handle title items
- Enhanced CSS for title items to improve visual distinction.